### PR TITLE
tox.ini: Add whitelist_externals

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -7,7 +7,10 @@
 envlist = py26, py27, py32, py33, py34, pypy
 
 [testenv]
-commands = echo "SELECT 1 + 2;" | sqlalchemy_sql_shell sqlite:///
 deps =
     sqlalchemy
     texttable
+whitelist_externals =
+    echo
+    sh
+commands = sh -c 'echo "SELECT 1 + 2;" | sqlalchemy_sql_shell sqlite:///'


### PR DESCRIPTION
and also rewrite command so that it actually outputs to console.

```
❯ tox
GLOB sdist-make: /Users/marca/dev/git-repos/sqlalchemy_sql_shell/setup.py
py26 inst-nodeps: /Users/marca/dev/git-repos/sqlalchemy_sql_shell/.tox/dist/sqlalchemy_sql_shell-0.0.0.zip
py26 runtests: PYTHONHASHSEED='2978569980'
py26 runtests: commands[0] | sh -c echo "SELECT 1 + 2;" | sqlalchemy_sql_shell sqlite:///
+-------+
| 1 + 2 |
+=======+
| 3     |
+-------+

py27 inst-nodeps: /Users/marca/dev/git-repos/sqlalchemy_sql_shell/.tox/dist/sqlalchemy_sql_shell-0.0.0.zip
py27 runtests: PYTHONHASHSEED='2978569980'
py27 runtests: commands[0] | sh -c echo "SELECT 1 + 2;" | sqlalchemy_sql_shell sqlite:///
+-------+
| 1 + 2 |
+=======+
| 3     |
+-------+

py32 inst-nodeps: /Users/marca/dev/git-repos/sqlalchemy_sql_shell/.tox/dist/sqlalchemy_sql_shell-0.0.0.zip
py32 runtests: PYTHONHASHSEED='2978569980'
py32 runtests: commands[0] | sh -c echo "SELECT 1 + 2;" | sqlalchemy_sql_shell sqlite:///
+-------+
| 1 + 2 |
+=======+
| 3     |
+-------+

py33 inst-nodeps: /Users/marca/dev/git-repos/sqlalchemy_sql_shell/.tox/dist/sqlalchemy_sql_shell-0.0.0.zip
py33 runtests: PYTHONHASHSEED='2978569980'
py33 runtests: commands[0] | sh -c echo "SELECT 1 + 2;" | sqlalchemy_sql_shell sqlite:///
+-------+
| 1 + 2 |
+=======+
| 3     |
+-------+

py34 inst-nodeps: /Users/marca/dev/git-repos/sqlalchemy_sql_shell/.tox/dist/sqlalchemy_sql_shell-0.0.0.zip
py34 runtests: PYTHONHASHSEED='2978569980'
py34 runtests: commands[0] | sh -c echo "SELECT 1 + 2;" | sqlalchemy_sql_shell sqlite:///
+-------+
| 1 + 2 |
+=======+
| 3     |
+-------+

pypy inst-nodeps: /Users/marca/dev/git-repos/sqlalchemy_sql_shell/.tox/dist/sqlalchemy_sql_shell-0.0.0.zip
pypy runtests: PYTHONHASHSEED='2978569980'
pypy runtests: commands[0] | sh -c echo "SELECT 1 + 2;" | sqlalchemy_sql_shell sqlite:///
+-------+
| 1 + 2 |
+=======+
| 3     |
+-------+

_________________________________________________________________________________________________________________________________________________________ summary __________________________________________________________________________________________________________________________________________________________
  py26: commands succeeded
  py27: commands succeeded
  py32: commands succeeded
  py33: commands succeeded
  py34: commands succeeded
  pypy: commands succeeded
  congratulations :)
```
